### PR TITLE
Damage dealt ui integrated when enemy is damaged

### DIFF
--- a/Tower Defense/Assets/_Main/Assets/Prefabs/Enemies/Sphere.prefab
+++ b/Tower Defense/Assets/_Main/Assets/Prefabs/Enemies/Sphere.prefab
@@ -160,6 +160,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseHealth: 0
   extraHealthModifier: 1
+  damageDealtPrefab: {fileID: 7210074580203829540, guid: 3969ec878ab79473b90c6d31982b68af,
+    type: 3}
   realHealth: 1
   onHealthDepleted:
     m_PersistentCalls:

--- a/Tower Defense/Assets/_Main/Assets/Prefabs/UI.meta
+++ b/Tower Defense/Assets/_Main/Assets/Prefabs/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0954839a95294452c92f435365c81834
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tower Defense/Assets/_Main/Assets/Prefabs/UI/Damage Dealt.prefab
+++ b/Tower Defense/Assets/_Main/Assets/Prefabs/UI/Damage Dealt.prefab
@@ -1,0 +1,228 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2007894695780310372
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4369143792112150419}
+  - component: {fileID: 2518989919149207574}
+  - component: {fileID: 1355178339848524253}
+  - component: {fileID: 6496655994523472698}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4369143792112150419
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2007894695780310372}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1827864703820742324}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: 50, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2518989919149207574
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2007894695780310372}
+  m_CullTransparentMesh: 0
+--- !u!114 &1355178339848524253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2007894695780310372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0.05529642, a: 1}
+  m_RaycastTarget: 0
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 35
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 7
+    m_MaxSize: 72
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 0
+--- !u!114 &6496655994523472698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2007894695780310372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 2, y: 2}
+  m_UseGraphicAlpha: 1
+--- !u!1 &6528259626953295845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1827864703820742324}
+  - component: {fileID: 1518954350556828778}
+  - component: {fileID: 8052070622113205601}
+  - component: {fileID: 29715597333803491}
+  - component: {fileID: 2947981781376823116}
+  - component: {fileID: 7210074580203829540}
+  m_Layer: 5
+  m_Name: Damage Dealt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1827864703820742324
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6528259626953295845}
+  m_LocalRotation: {x: 0.19768277, y: -0.6782691, z: 0.19802794, w: 0.6794539}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.019916441, y: 0.019916441, z: 0.019916441}
+  m_Children:
+  - {fileID: 4369143792112150419}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 32.498, y: -89.881004, z: 0.064}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.8183594}
+  m_SizeDelta: {x: 50, y: 250}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!223 &1518954350556828778
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6528259626953295845}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &8052070622113205601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6528259626953295845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &29715597333803491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6528259626953295845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!225 &2947981781376823116
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6528259626953295845}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
+--- !u!114 &7210074580203829540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6528259626953295845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d80f35a69aeac45e7b80250277336248, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  canvasGroup: {fileID: 2947981781376823116}
+  textRectTransform: {fileID: 4369143792112150419}
+  text: {fileID: 1355178339848524253}
+  startHeight: -50
+  endHeight: 60
+  fadeDuration: 0.2
+  movementDuration: 0.8

--- a/Tower Defense/Assets/_Main/Assets/Prefabs/UI/Damage Dealt.prefab.meta
+++ b/Tower Defense/Assets/_Main/Assets/Prefabs/UI/Damage Dealt.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3969ec878ab79473b90c6d31982b68af
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tower Defense/Assets/_Main/Scenes/Main.unity
+++ b/Tower Defense/Assets/_Main/Scenes/Main.unity
@@ -20474,6 +20474,7 @@ Transform:
   - {fileID: 763023739}
   - {fileID: 745158794}
   - {fileID: 1300818636}
+  - {fileID: 1102735267}
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -20587,6 +20588,70 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1102735266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1102735267}
+  - component: {fileID: 1102735269}
+  - component: {fileID: 1102735268}
+  m_Layer: 0
+  m_Name: Damage Dealt Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1102735267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1102735266}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 997831062}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1102735268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1102735266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0166d8ff8d905b048b2448179e1f5d11, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _components:
+  - {fileID: 1102735269}
+  _identifier: 
+  _useSceneContext: 0
+  _context: {fileID: 0}
+  _bindType: 0
+--- !u!114 &1102735269
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1102735266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 671c93aa751de49ffa28e777b2d099b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1102735267}
+  useZenject: 0
 --- !u!1001 &1138944810
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Tower Defense/Assets/_Main/Scripts/Enemies/EnemyHealth.cs
+++ b/Tower Defense/Assets/_Main/Scripts/Enemies/EnemyHealth.cs
@@ -4,6 +4,8 @@ using UnityEngine.Events;
 using Zenject;
 using Utilities.Inspector;
 
+using TowerDefense.UI;
+
 namespace TowerDefense.Enemies
 {
     public class EnemyHealth : MonoBehaviour
@@ -11,10 +13,14 @@ namespace TowerDefense.Enemies
         #region FIELDS
 
         [Inject] private WavesManager wavesManager = null;
+        [Inject] private DamageDealtPool damageDealtPool = null;
 
         [Header("CONFIGURATION")]
         [SerializeField] private float baseHealth = 1;
         [SerializeField] private float extraHealthModifier = 1;
+        [SerializeField] private DamageDealtUI damageDealtPrefab = null;
+
+        [Header("STATES")]
         [ReadOnly] [SerializeField] private float realHealth = 1;
 
         #endregion
@@ -40,6 +46,7 @@ namespace TowerDefense.Enemies
 
         public void DecreaseHealth(float damage)
         {
+            damageDealtPool.Spawn(damageDealtPrefab, transform.position, damageDealtPrefab.transform.rotation).LoadDamageDealt(damage);
             realHealth -= damage;
 
             if (realHealth <= 0)

--- a/Tower Defense/Assets/_Main/Scripts/UI.meta
+++ b/Tower Defense/Assets/_Main/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e5356d888b044c2485782f53b5fb369
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtPool.cs
+++ b/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtPool.cs
@@ -1,0 +1,7 @@
+﻿using Utilities.Pooling;
+
+namespace TowerDefense.UI
+{
+    public class DamageDealtPool : GameObjectPool<DamageDealtUI>
+    { }
+}

--- a/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtPool.cs.meta
+++ b/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 671c93aa751de49ffa28e777b2d099b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtUI.cs
+++ b/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtUI.cs
@@ -1,0 +1,58 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+using DG.Tweening;
+
+namespace TowerDefense.UI
+{
+    public class DamageDealtUI : MonoBehaviour
+    {
+        #region FIELDS
+
+        [Header("COMPONENTS")]
+        [SerializeField] private CanvasGroup canvasGroup = null;
+        [SerializeField] private RectTransform textRectTransform = null;
+        [SerializeField] private Text text = null;
+
+        [Header("TWEEN")]
+        [SerializeField] private float startHeight = -50;
+        [SerializeField] private float endHeight = 50;
+        [SerializeField] private float fadeDuration = 0.2f;
+        [SerializeField] private float movementDuration = 0.8f;
+
+        private Sequence tweenSequence = null;
+
+        #endregion
+
+        #region BEHAVIORS
+
+        public void LoadDamageDealt(float damage)
+        {
+            text.text = ((int)damage).ToString();
+            ShowTween();
+        }
+
+        private void ShowTween()
+        {
+            tweenSequence = DOTween.Sequence();
+
+            var time = 0f;
+            tweenSequence.Insert(time, canvasGroup.DOFade(1, fadeDuration).From(0));
+            tweenSequence.Insert(time, textRectTransform.DOAnchorPosY(endHeight, movementDuration).From(Vector2.up * startHeight));
+
+            time += movementDuration - fadeDuration;
+
+            tweenSequence.Insert(time, canvasGroup.DOFade(0, fadeDuration).From(1));
+            tweenSequence.AppendCallback(Destroy);
+
+            gameObject.SetActive(true);
+        }
+
+        private void Destroy()
+        {
+            gameObject.SetActive(false);
+        }
+
+        #endregion
+    }
+}

--- a/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtUI.cs.meta
+++ b/Tower Defense/Assets/_Main/Scripts/UI/DamageDealtUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d80f35a69aeac45e7b80250277336248
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Every time an enemy receives damage a message appears with the amount of damage dealt.

![Damage dealt](https://user-images.githubusercontent.com/16009004/104858164-059e1a00-58e3-11eb-9736-2bfa6d1ceb1c.gif)

EDIT:

After watching the gif I changed it to a health bar system that looks better and gives more information with less effort.

![HP Bar](https://user-images.githubusercontent.com/16009004/104863550-ec559780-58fb-11eb-8bab-2c54e100802f.gif)

Closes #8 